### PR TITLE
修复链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-<h1 align=center>HiteTool</h1>
+<h1 align="center">HiteTool</h1>
 <center>鸿合科技开发的辅助工具</center>
 
 
-这是从[鸿合科技](www.hitevision.com)的[软件](https://pie.hitecloud.cn/pie)中提取出来的内容。这里面有倒计时、高光等内容。
+这是从[鸿合科技](https://www.hitevision.com/)的[软件](https://pie.hitecloud.cn/pie)中提取出来的内容。这里面有倒计时、高光等内容。
 ![](https://i.loli.net/2020/01/30/bPquLhgvKkNUBef.jpg)
 
 `HiteClock.exe`集成了时钟、倒计时和秒表。


### PR DESCRIPTION
老弟，如果你Markdown里链接没有`http://`或者`https://`，Markdown就会认为这是当前目录下的一个目录。
例如，你想表达`https://github.com/`，而你写成了`github.com`，那么你若在项目首页的README上单击链接，这会指向到
https://github.com/SunbossRS/HiteTool/github.com

404 NOT FOUND